### PR TITLE
Factor out alphabet

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -14,14 +14,17 @@ parse r =
     Right x -> x
     Left _ -> error "Couldn't parse"
 
+alphabet :: String
+alphabet = "01"
+
 constructThompsons :: String -> ENFA Int Char
 constructThompsons = thompsons . parse
 
 constructSubset :: String -> DFA (Set Int) Char
-constructSubset = subset . thompsons . parse
+constructSubset = subset alphabet . thompsons . parse
 
 constructMinimized :: String -> DFA (Set Int) Char
-constructMinimized = minimize . subset . thompsons . parse
+constructMinimized = minimize . subset alphabet . thompsons . parse
 
 constructMatrix
   :: Int
@@ -30,7 +33,7 @@ constructMatrix
 constructMatrix n =
     toMatrices' n
   . minimize
-  . subset
+  . subset alphabet
   . thompsons
   . parse
     where

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -38,9 +38,10 @@ main = do
     Left err -> do
       error $ "Failed to parse, error: " ++ show err
     Right regex' -> do
-      let thompson  = thompsons regex'
+      let alphabet  = "01" :: String
+          thompson  = thompsons regex'
           closure   = getClosure thompson
-          subset'   = subset thompson
+          subset'   = subset alphabet thompson
           minimized = minimize subset'
           matrices  = premultiply (fromMaybe 1 chunks) $ toMatrices inputLength minimized
       BL.writeFile output $ encode (Matrices inputLength matrices)

--- a/src/Regex/MBP.hs
+++ b/src/Regex/MBP.hs
@@ -36,8 +36,8 @@ buildStep
   -> (Map a (Matrix Int), Set s)
 buildStep DFA {..} srcs = (M.map fromLists matrices, tgts)
   where
-    alphabet = Prelude.map snd (M.keys trans)
-    matrices = M.fromList [ (a, matrixFor a) | a <- alphabet ]
+    ks = Prelude.map snd (M.keys trans)
+    matrices = M.fromList [ (a, matrixFor a) | a <- ks ]
     matrixFor a = [
         [ if M.lookup (src,a) trans == Just tgt
             then 1
@@ -50,7 +50,7 @@ buildStep DFA {..} srcs = (M.map fromLists matrices, tgts)
       S.fromList . catMaybes $
         [ x
         | s <- S.toList srcs
-        , a <- alphabet
+        , a <- ks
         , let x = M.lookup (s, a) trans
         ]
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,131 +18,134 @@ positiveInts :: Alias Gen
 positiveInts = alias $ \() ->
   getPositive <$> arbitrary :: Gen Int
 
+alphabet :: String
+alphabet = "01"
+
 main :: IO ()
 main =
   hspec $ do
     describe "regex-fsm tests" $ do
-      it "Should successfully simulate (a|b) on an ENFA" $ do
-        let Right regex = parseRegex "(a|b)"
+      it "Should successfully simulate (0|1) on an ENFA" $ do
+        let Right regex = parseRegex "(0|1)"
             thompson = thompsons regex :: ENFA Int Char
-        simulateENFA "a" thompson `shouldBe` True
-        simulateENFA "b" thompson  `shouldBe` True
+        simulateENFA "0" thompson `shouldBe` True
+        simulateENFA "1" thompson  `shouldBe` True
         simulateENFA "c" thompson `shouldBe` False
         simulateENFA "" thompson `shouldBe` False
 
-      it "Should successfully simulate (a*b) on an ENFA" $ do
-        let Right regex = parseRegex "(a*b)"
+      it "Should successfully simulate (0*1) on an ENFA" $ do
+        let Right regex = parseRegex "(0*1)"
             thompson = thompsons regex :: ENFA Int Char
         simulateENFA "" thompson `shouldBe` False
-        simulateENFA "b" thompson `shouldBe` True
-        simulateENFA "ab" thompson `shouldBe` True
-        simulateENFA "bb" thompson `shouldBe` False
-        simulateENFA "aaaaab" thompson `shouldBe` True
+        simulateENFA "1" thompson `shouldBe` True
+        simulateENFA "01" thompson `shouldBe` True
+        simulateENFA "11" thompson `shouldBe` False
+        simulateENFA "000001" thompson `shouldBe` True
 
-      it "Should successfully simulate (a*|b*) on an ENFA" $ do
-        let Right regex = parseRegex "(a*|b*)"
+      it "Should successfully simulate (0*|1*) on an ENFA" $ do
+        let Right regex = parseRegex "(0*|1*)"
             thompson = thompsons regex :: ENFA Int Char
         simulateENFA "" thompson `shouldBe` True
-        simulateENFA "ab" thompson `shouldBe` False
-        simulateENFA "a" thompson `shouldBe` True
-        simulateENFA "b" thompson `shouldBe` True
-        simulateENFA (replicate 100 'a') thompson `shouldBe` True
-        simulateENFA (replicate 100 'b') thompson `shouldBe` True
+        simulateENFA "01" thompson `shouldBe` False
+        simulateENFA "0" thompson `shouldBe` True
+        simulateENFA "1" thompson `shouldBe` True
+        simulateENFA (replicate 100 '0') thompson `shouldBe` True
+        simulateENFA (replicate 100 '1') thompson `shouldBe` True
 
-      it "Should successfully simulate (a|b) on a DFA" $ do
-        let Right regex = parseRegex "(a|b)"
-            dfa :: DFA (Set Int) Char = subset (thompsons regex)
-        simulateDFA "a" dfa `shouldBe` True
-        simulateDFA "b" dfa `shouldBe` True
+      it "Should successfully simulate (0|1) on a DFA" $ do
+        let Right regex = parseRegex "(0|1)"
+            dfa :: DFA (Set Int) Char = subset alphabet (thompsons regex)
+        simulateDFA "0" dfa `shouldBe` True
+        simulateDFA "1" dfa `shouldBe` True
         simulateDFA "c" dfa `shouldBe` False
         simulateDFA "" dfa `shouldBe` False
 
-      it "Should successfully simulate (a*b) on a DFA" $ do
-        let Right regex = parseRegex "(a*b)"
-            dfa :: DFA (Set Int) Char = subset (thompsons regex)
+      it "Should successfully simulate (0*1) on a DFA" $ do
+        let Right regex = parseRegex "(0*1)"
+            dfa :: DFA (Set Int) Char = subset alphabet (thompsons regex)
         simulateDFA "" dfa `shouldBe` False
-        simulateDFA "b" dfa `shouldBe` True
-        simulateDFA "ab" dfa `shouldBe` True
-        simulateDFA "bb" dfa `shouldBe` False
-        simulateDFA "aaaaab" dfa `shouldBe` True
+        simulateDFA "1" dfa `shouldBe` True
+        simulateDFA "01" dfa `shouldBe` True
+        simulateDFA "11" dfa `shouldBe` False
+        simulateDFA "0000001" dfa `shouldBe` True
 
-      it "Should successfully simulate (a*|b*) on a DFA" $ do
-        let Right regex = parseRegex "(a*|b*)"
-            dfa :: DFA (Set Int) Char = subset (thompsons regex)
+      it "Should successfully simulate (0*|1*) on a DFA" $ do
+        let Right regex = parseRegex "(0*|1*)"
+            dfa :: DFA (Set Int) Char = subset alphabet (thompsons regex)
         simulateDFA "" dfa `shouldBe` True
-        simulateDFA "ab" dfa `shouldBe` False
-        simulateDFA "a" dfa `shouldBe` True
-        simulateDFA "b" dfa `shouldBe` True
-        simulateDFA (replicate 100 'a') dfa `shouldBe` True
-        simulateDFA (replicate 100 'b') dfa `shouldBe` True
+        simulateDFA "01" dfa `shouldBe` False
+        simulateDFA "0" dfa `shouldBe` True
+        simulateDFA "0" dfa `shouldBe` True
+        simulateDFA (replicate 100 '0') dfa `shouldBe` True
+        simulateDFA (replicate 100 '1') dfa `shouldBe` True
 
-      it "Should successfully simulate (a|b) on a minimized DFA" $ do
-        let Right regex = parseRegex "(a|b)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
-        simulateDFA "a" dfa `shouldBe` True
-        simulateDFA "b" dfa `shouldBe` True
+      it "Should successfully simulate (0|1) on a minimized DFA" $ do
+        let Right regex = parseRegex "(0|1)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
+        simulateDFA "0" dfa `shouldBe` True
+        simulateDFA "1" dfa `shouldBe` True
         simulateDFA "c" dfa `shouldBe` False
         simulateDFA "" dfa `shouldBe` False
 
-      it "Should successfully simulate (a*b) on a minimized DFA" $ do
-        let Right regex = parseRegex "(a*b)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      it "Should successfully simulate (0*1) on a minimized DFA" $ do
+        let Right regex = parseRegex "(0*1)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
         simulateDFA "" dfa `shouldBe` False
-        simulateDFA "b" dfa `shouldBe` True
-        simulateDFA "ab" dfa `shouldBe` True
-        simulateDFA "bb" dfa `shouldBe` False
-        simulateDFA "aaaaab" dfa `shouldBe` True
+        simulateDFA "1" dfa `shouldBe` True
+        simulateDFA "01" dfa `shouldBe` True
+        simulateDFA "11" dfa `shouldBe` False
+        simulateDFA "0000001" dfa `shouldBe` True
 
-      it "Should successfully simulate (a*|b*) on a minimized DFA" $ do
-        let Right regex = parseRegex "(a*|b*)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      it "Should successfully simulate (0*|1*) on a minimized DFA" $ do
+        let Right regex = parseRegex "(0*|1*)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
         simulateDFA "" dfa `shouldBe` True
-        simulateDFA "ab" dfa `shouldBe` False
-        simulateDFA "a" dfa `shouldBe` True
-        simulateDFA "b" dfa `shouldBe` True
-        simulateDFA (replicate 100 'a') dfa `shouldBe` True
-        simulateDFA (replicate 100 'b') dfa `shouldBe` True
+        simulateDFA "01" dfa `shouldBe` False
+        simulateDFA "0" dfa `shouldBe` True
+        simulateDFA "1" dfa `shouldBe` True
+        simulateDFA (replicate 100 '0') dfa `shouldBe` True
+        simulateDFA (replicate 100 '1') dfa `shouldBe` True
 
-      it "Should successfully simulate (a|b) on a MBP" $ do
-        let Right regex = parseRegex "(a|b)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      it "Should successfully simulate (0|1) on a MBP" $ do
+        let Right regex = parseRegex "(0|1)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
-        test "a" `shouldBe` True
-        test "b" `shouldBe` True
+        test "0" `shouldBe` True
+        test "1" `shouldBe` True
         test "c" `shouldBe` False
 
-      it "Should successfully simulate (a*b) on a MBP" $ do
-        let Right regex = parseRegex "(a*b)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      it "Should successfully simulate (0*1) on a MBP" $ do
+        let Right regex = parseRegex "(0*1)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
-        test "b" `shouldBe` True
-        test "ab" `shouldBe` True
-        test "bb" `shouldBe` False
-        test "aaaaab" `shouldBe` True
+        test "1" `shouldBe` True
+        test "01" `shouldBe` True
+        test "11" `shouldBe` False
+        test "0000001" `shouldBe` True
 
-      it "Should successfully simulate (a*|b*) on a MBP" $ do
-        let Right regex = parseRegex "(a*|b*)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      it "Should successfully simulate (0*|1*) on a MBP" $ do
+        let Right regex = parseRegex "(0*|1*)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
-        test "ab" `shouldBe` False
-        test "a" `shouldBe` True
-        test "b" `shouldBe` True
-        test (replicate 100 'a') `shouldBe` True
-        test (replicate 100 'b') `shouldBe` True
+        test "01" `shouldBe` False
+        test "0" `shouldBe` True
+        test "1" `shouldBe` True
+        test (replicate 100 '0') `shouldBe` True
+        test (replicate 100 '1') `shouldBe` True
 
-      it "Should successfully simulate (a*|b*)abc(a*|b*) on a MBP" $ do
-        let Right regex = parseRegex "(a*|b*)abc(a*|b*)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      it "Should successfully simulate (0*|1*)010(0*|0*) on a MBP" $ do
+        let Right regex = parseRegex "(0*|1*)010(0*|1*)"
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
-        test "a" `shouldBe` False
-        test "b" `shouldBe` False
-        test "c" `shouldBe` False
-        test "abc" `shouldBe` True
-        test "aabcaa" `shouldBe` True
+        test "0" `shouldBe` False
+        test "1" `shouldBe` False
+        test "000" `shouldBe` False
+        test "010" `shouldBe` True
+        test "000010111" `shouldBe` True
 
       it "Should successfully simulate 01110101000010010110011010000011 on a MBP" $ do
         let Right regex = parseRegex "01110101000010010110011010000011"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
         test "01110101000010010110011010000011" `shouldBe` True
         test "01110101000010010110011010000010" `shouldBe` False
@@ -155,7 +158,7 @@ main =
 
       it "Should successfully simulate 1(0|1)(0|1)1(0|1)01(0|1)000001101010101010(0|1)101(0|1)(0|1) on a MBP" $ do
         let Right regex = parseRegex "1(0|1)(0|1)1(0|1)01(0|1)000001101010101010(0|1)101(0|1)(0|1)"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
         test "10010010000001101010101010110101" `shouldBe` True
         test "11111011000001101010101010110111" `shouldBe` True
@@ -168,7 +171,7 @@ main =
 
       it "Should successfully simulate (0|1)*0101010000110000(0|1)* on a MBP" $ do
         let Right regex = parseRegex "(0|1)*0101010000110000(0|1)*"
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test x = simulateMBP x (toMatrices (length x) dfa)
         test "0101010000110000" `shouldBe` True
         test "010101010100001100000101" `shouldBe` True
@@ -182,7 +185,7 @@ main =
       it "Should successfully simulate 01110101000010010110011010000011 on a premultiplied MBP" $ do
         let Right regex = parseRegex "01110101000010010110011010000011"
             input = "01110101000010010110011010000011" :: String
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test n = simulateMBPChunks n input $ toMatrices (length input) dfa
         test 16 `shouldBe` True
         test 8  `shouldBe` True
@@ -193,7 +196,7 @@ main =
       it "Should successfully simulate 1(0|1)(0|1)1(0|1)01(0|1)000001101010101010(0|1)101(0|1)(0|1) on a premultiplied MBP" $ do
         let Right regex = parseRegex "1(0|1)(0|1)1(0|1)01(0|1)000001101010101010(0|1)101(0|1)(0|1)"
             input = "10010010000001101010101010010100" :: String
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test n = simulateMBPChunks n input $ toMatrices (length input) dfa
         test 16 `shouldBe` True
         test 8  `shouldBe` True
@@ -204,7 +207,7 @@ main =
       it "Should successfully simulate (0|1)*0101010000110000(0|1)* on a MBP" $ do
         let Right regex = parseRegex "(0|1)*0101010000110000(0|1)*"
             input = "000001010100001100001111" :: String
-            dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+            dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
             test n = simulateMBPChunks n input $ toMatrices (length input) dfa
         test 12 `shouldBe` True
         test 8  `shouldBe` True

--- a/test/Obfuscator.hs
+++ b/test/Obfuscator.hs
@@ -153,6 +153,9 @@ type ProcessArg = String
 type SecParam = Int
 type Length = Int
 
+alphabet :: String
+alphabet = "01"
+
 testObfuscatorWithSecurity
   :: String
   -> RegexString
@@ -163,7 +166,7 @@ testObfuscatorWithSecurity
   -> IO ()
 testObfuscatorWithSecurity path str arg n secParam chunks = do
   let Right regex = parseRegex str
-      dfa :: DFA (Set Int) Char = minimize $ subset (thompsons regex)
+      dfa :: DFA (Set Int) Char = minimize $ subset alphabet (thompsons regex)
       test = Matrices n $ premultiply chunks (toMatrices n dfa)
       fileName =
         if Prelude.null path


### PR DESCRIPTION
- During `DFA` construction, ensure all members of alphabet are traversed.
- Updated tests to work with binary alphabet.